### PR TITLE
loris setup to use dual jp2 transformers

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -124,6 +124,10 @@ target_formats = ['jpg','png','gif','webp']
     mkfifo = '/usr/bin/mkfifo' # r-x
     map_profile_to_srgb = False
     srgb_profile_fp = '/usr/share/color/icc/colord/sRGB.icc' # r--
+    #dual transformer support
+    impl2 = 'OPJ_JP2Transformer'
+    opj_decompress = '/usr/local/bin/opj_decompress' # r-x
+    opj_libs = '/usr/local/lib' # r--
 
 #   Sample config for the OpenJPEG Transformer
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -121,7 +121,7 @@ class ImageInfo(JP2Extractor, object):
         # If constructed from JSON, the pixel info will already be processed
         if app:
             try:
-                loaded_transformers = app.transformers[image_info.src_format]
+                loaded_transformers = app.transformers[src_format]
                 #if both transforms if loaded, pick the first instance of target_formats
                 if isinstance(loaded_transformers, tuple):
                     transformer1 = loaded_transformers[0]

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -121,7 +121,13 @@ class ImageInfo(JP2Extractor, object):
         # If constructed from JSON, the pixel info will already be processed
         if app:
             try:
-                formats = app.transformers[src_format].target_formats
+                loaded_transformers = app.transformers[image_info.src_format]
+                #if both transforms if loaded, pick the first instance of target_formats
+                if isinstance(loaded_transformers, tuple):
+                    transformer1 = loaded_transformers[0]
+                    formats = transformer1.target_formats
+                else:
+                    formats = app.transformers[src_format].target_formats
             except KeyError:
                 raise ImageInfoException(
                     "Didn't get a source format, or at least one we recognize (%r)." %

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -322,7 +322,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
             # TODO: If this command hangs, the server never returns.
             # Surely that can't be right!
             opj_decompress_proc = subprocess.Popen(opj_cmd, shell=True, bufsize=-1,
-               stderr=subprocess.PIPE, stdout=fnull, env=self.env)
+               stderr=subprocess.PIPE, env=self.env)
             with open(fifo_fp, 'rb') as f:
                 # read from the named pipe
                 p = Parser()

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -255,10 +255,10 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
                 'LD_LIBRARY_PATH' : config['opj_libs'],
                 'PATH' : config['opj_decompress']
             }
-            super(OPJ_JP2Transformer, self).__init__(config)
+            #super(OPJ_JP2Transformer, self).__init__(config)
             #new
            self.transform_timeout = config.get('timeout', 120)
-           super(KakaduJP2Transformer, self).__init__(config)
+           super(OPJ_JP2Transformer, self).__init__(config)
 
 
         @staticmethod

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -65,12 +65,12 @@ class _AbstractTransformer(object):
         self.dither_bitonal_images = config['dither_bitonal_images']
         logger.debug('Initialized %s.%s', __name__, self.__class__.__name__)
 
-    def transform(self, src_fp, target_fp, image_request):
+    def transform(self, target_fp, image_request, image_info):
         '''
         Args:
-            src_fp (str)
             target_fp (str)
-            image (ImageRequest)
+            image_request (ImageRequest)
+            image_info (ImageInfo)
         '''
         cn = self.__class__.__name__
         raise NotImplementedError('transform() not implemented for %s' % (cn,))
@@ -86,7 +86,7 @@ class _AbstractTransformer(object):
     def _map_im_profile_to_srgb(self, im, input_profile):
         return profileToProfile(im, input_profile, self.srgb_profile_fp)
 
-    def _derive_with_pil(self, im, target_fp, image_request, rotate=True, crop=True):
+    def _derive_with_pil(self, im, target_fp, image_request, image_info, rotate=True, crop=True):
         '''
         Once you have a PIL.Image, this can be used to do the IIIF operations.
 
@@ -94,6 +94,7 @@ class _AbstractTransformer(object):
             im (PIL.Image)
             target_fp (str)
             image_request (ImageRequest)
+            image_info (ImageInfo)
             rotate (bool):
                 True by default; can be set to False in case the rotation was
                 done further upstream.
@@ -104,27 +105,31 @@ class _AbstractTransformer(object):
             void (puts an image at target_fp)
 
         '''
+        region_param = image_request.region_param(image_info=image_info)
 
-        if crop and image_request.region_param.canonical_uri_value != 'full':
+        if crop and region_param.canonical_uri_value != 'full':
             # For PIL: "The box is a 4-tuple defining the left, upper, right,
             # and lower pixel coordinate."
             box = (
-                image_request.region_param.pixel_x,
-                image_request.region_param.pixel_y,
-                image_request.region_param.pixel_x+image_request.region_param.pixel_w,
-                image_request.region_param.pixel_y+image_request.region_param.pixel_h
+                region_param.pixel_x,
+                region_param.pixel_y,
+                region_param.pixel_x + region_param.pixel_w,
+                region_param.pixel_y + region_param.pixel_h
             )
             logger.debug('cropping to: %r', box)
             im = im.crop(box)
 
         # resize
-        if image_request.size_param.canonical_uri_value != 'full':
-            wh = [int(image_request.size_param.w),int(image_request.size_param.h)]
+        size_param = image_request.size_param(image_info=image_info)
+
+        if size_param.canonical_uri_value != 'full':
+            wh = [int(size_param.w), int(size_param.h)]
             logger.debug('Resizing to: %r', wh)
             im = im.resize(wh, resample=Image.ANTIALIAS)
 
+        rotation_param = image_request.rotation_param()
 
-        if image_request.rotation_param.mirror:
+        if rotation_param.mirror:
             im = mirror(im)
 
         try:
@@ -132,16 +137,20 @@ class _AbstractTransformer(object):
                 embedded_profile = BytesIO(im.info['icc_profile'])
                 im = self._map_im_profile_to_srgb(im, embedded_profile)
         except PyCMSError as err:
-            logger.warn('Error converting %r to sRGB: %r', im, err)
+            logger.warn(
+                'Error converting %r (%r) to sRGB: %r',
+                image_request.ident, image_info.src_img_fp, err
+            )
 
-        if image_request.rotation_param.rotation != '0' and rotate:
-            r = 0-float(image_request.rotation_param.rotation)
+        if rotation_param.rotation != '0' and rotate:
+            r = 0 - float(rotation_param.rotation)
 
             # We need to convert pngs here and not below if we want a
             # transparent background (A == Alpha layer)
-            if float(image_request.rotation_param.rotation) % 90 != 0.0 and \
-                image_request.format == 'png':
-
+            if (
+                float(rotation_param.rotation) % 90 != 0.0 and
+                image_request.format == 'png'
+            ):
                 if image_request.quality in ('gray', 'bitonal'):
                     im = im.convert('LA')
                 else:
@@ -149,8 +158,17 @@ class _AbstractTransformer(object):
 
             im = im.rotate(r, expand=True)
 
-        if not im.mode.endswith('A'):
-            if im.mode != "RGB" and not image_request.quality in ('gray', 'bitonal'):
+        # If the source format is a PNG image with transparency (mode RGBA)
+        # and we're writing as a non-transparent format (e.g. RGB), we need
+        # to remove the transparency here.
+        if (
+            not im.mode.endswith('A') or
+            (im.mode == 'RGBA' and image_request.format != 'png')
+        ):
+            if (
+                im.mode != "RGB" and
+                image_request.quality not in ('gray', 'bitonal')
+            ):
                 im = im.convert("RGB")
 
             elif image_request.quality == 'gray':
@@ -172,6 +190,9 @@ class _AbstractTransformer(object):
         elif image_request.format == 'gif':
             # see http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#gif
             im.save(target_fp)
+        
+        elif image_request.format == 'tif':
+            im.save(target_fp, compression='tiff_lzw')
 
         elif image_request.format == 'webp':
             # see http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#webp
@@ -179,24 +200,29 @@ class _AbstractTransformer(object):
 
 
 class _PillowTransformer(_AbstractTransformer):
-    def __init__(self, config):
-        super(_PillowTransformer, self).__init__(config)
+    def transform(self, target_fp, image_request, image_info):
+        im = Image.open(image_info.src_img_fp)
+        self._derive_with_pil(
+            im=im,
+            target_fp=target_fp,
+            image_request=image_request,
+            image_info=image_info
+        )
 
-    def transform(self, src_fp, target_fp, image_request):
-        im = Image.open(src_fp)
-        self._derive_with_pil(im, target_fp, image_request)
 
 class JPG_Transformer(_PillowTransformer):
-    def __init__(self, config): super(JPG_Transformer, self).__init__(config)
+    pass
 
-class GIF_Transformer(_PillowTransformer):
-    def __init__(self, config): super(GIF_Transformer, self).__init__(config)
 
 class TIF_Transformer(_PillowTransformer):
-    def __init__(self, config): super(TIF_Transformer, self).__init__(config)
+    pass
+
 
 class PNG_Transformer(_PillowTransformer):
-    def __init__(self, config): super(PNG_Transformer, self).__init__(config)
+    pass
+
+class GIF_Transformer(_PillowTransformer):
+    pass
 
 class _AbstractJP2Transformer(_AbstractTransformer):
     '''
@@ -235,124 +261,143 @@ class _AbstractJP2Transformer(_AbstractTransformer):
                 if self._scale_dim(full_w,s) >= req_w and \
                     self._scale_dim(full_h,s) >= req_h])
 
-    def _scales_to_reduce_arg(self, image_request):
+    def _scales_to_reduce_arg(self, image_request, image_info):
         # Scales from JP2 levels, so even though these are from the tiles
         # info.json, it's easier than using the sizes from info.json
-        scales = [s for t in image_request.info.tiles for s in t['scaleFactors']]
-        is_full_region = image_request.region_param.mode == FULL_MODE
+        scales = [s for t in image_info.tiles for s in t['scaleFactors']]
+        is_full_region = image_request.region_param(image_info).mode == FULL_MODE
         arg = None
         if scales and is_full_region:
-            full_w = image_request.info.width
-            full_h = image_request.info.height
-            req_w = image_request.size_param.w
-            req_h = image_request.size_param.h
+            full_w = image_info.width
+            full_h = image_info.height
+            req_w = image_request.size_param(image_info).w
+            req_h = image_request.size_param(image_info).h
             closest_scale = self._get_closest_scale(req_w, req_h, full_w, full_h, scales)
             reduce_arg = int(log(closest_scale, 2))
             arg = str(reduce_arg)
         return arg
 
 class OPJ_JP2Transformer(_AbstractJP2Transformer):
-        def __init__(self, config):
-            self.opj_decompress = config['opj_decompress']
-            self.env = {
-                'LD_LIBRARY_PATH' : config['opj_libs'],
-                'PATH' : config['opj_decompress']
-            }
-            #super(OPJ_JP2Transformer, self).__init__(config)
-            #new
-            self.transform_timeout = config.get('timeout', 120)
-            super(OPJ_JP2Transformer, self).__init__(config)
+    def __init__(self, config):
+        self.opj_decompress = config['opj_decompress']
+        self.env = {
+            'LD_LIBRARY_PATH' : config['opj_libs'],
+            'PATH' : config['opj_decompress']
+        }
+        self.transform_timeout = config.get('timeout', 120)
+        super(OPJ_JP2Transformer, self).__init__(config)
 
+    @staticmethod
+    def local_opj_decompress_path():
+        '''Only used in dev and tests.
+        '''
+        return 'bin/%s/%s/opj_decompress' % (platform.system(),platform.machine())
 
-        @staticmethod
-        def local_opj_decompress_path():
-            '''Only used in dev and tests.
-            '''
-            return 'bin/%s/%s/opj_decompress' % (platform.system(),platform.machine())
+    @staticmethod
+    def local_libopenjp2_dir():
+        '''Only used in dev and tests.
+        '''
+        return 'lib/%s/%s' % (platform.system(),platform.machine())
 
-        @staticmethod
-        def local_libopenjp2_dir():
-            '''Only used in dev and tests.
-            '''
-            return 'lib/%s/%s' % (platform.system(),platform.machine())
+    def _region_to_opj_arg(self, region_param):
+        '''
+        Args:
+            region_param (params.RegionParam)
 
+        Returns (str): e.g. 'x0,y0,x1,y1'
+        '''
+        arg = None
+        if region_param.mode != 'full':
+            x0 = region_param.pixel_x
+            y0 = region_param.pixel_y
+            x1 = region_param.pixel_x + region_param.pixel_w
+            y1 = region_param.pixel_y + region_param.pixel_h
+            arg = ','.join(map(str, (x0, y0, x1, y1)))
+        logger.debug('opj region parameter: %s', arg)
+        return arg
 
-        def _region_to_opj_arg(self, region_param):
-            '''
-            Args:
-                region_param (params.RegionParam)
+    def _run_transform(self, target_fp, image_request, image_info, opj_cmd, fifo_fp):
+        try:
+            # Start the shellout. Blocks until the pipe is empty
+            # TODO: If this command hangs, the server never returns.
+            # Surely that can't be right!
+            opj_decompress_proc = subprocess.Popen(opj_cmd, shell=True, bufsize=-1,
+               stderr=subprocess.PIPE, stdout=fnull, env=self.env)
+            with open(fifo_fp, 'rb') as f:
+                # read from the named pipe
+                p = Parser()
+                while True:
+                    s = f.read(1024)
+                    if not s:
+                        break
+                    p.feed(s)
+                im = p.close() # a PIL.Image
+        finally:
+            stdoutdata, stderrdata = opj_decompress_proc.communicate()
+            opj_exit = opj_decompress_proc.returncode
+            if opj_exit != 0:
+                map(logger.error, stderrdata)
+            unlink(fifo_fp)
 
-            Returns (str): e.g. 'x0,y0,x1,y1'
-            '''
-            arg = None
-            if region_param.mode != 'full':
-                x0 = region_param.pixel_x
-                y0 = region_param.pixel_y
-                x1 = region_param.pixel_x + region_param.pixel_w
-                y1 = region_param.pixel_y + region_param.pixel_h
-                arg = ','.join(map(str, (x0, y0, x1, y1)))
-            logger.debug('opj region parameter: %s', arg)
-            return arg
+        try:
+            if self.map_profile_to_srgb and image_info.color_profile_bytes:
+                emb_profile = BytesIO(image_info.color_profile_bytes)
+                im = self._map_im_profile_to_srgb(im, emb_profile)
+        except PyCMSError as err: 
+            logger.warn('Error converting %r to sRGB: %r', im, err)
 
-        def _run_transform(self, target_fp, image_request, opj_cmd, fifo_fp):
-           try:
-                # Start the shellout. Blocks until the pipe is empty
-                opj_decompress_proc = subprocess.Popen(opj_cmd, shell=True, bufsize=-1,
-                    stderr=subprocess.PIPE, env=self.env)
-                with open(fifo_fp, 'rb') as f:
-                    # read from the named pipe
-                    p = Parser()
-                    while True:
-                        s = f.read(1024)
-                        if not s:
-                            break
-                        p.feed(s)
-                    im = p.close() # a PIL.Image
-           finally:
-                stdoutdata, stderrdata = opj_expand_proc.communicate()
-                opj_exit = opj_expand_proc.returncode
-                if opj_exit != 0:
-                    map(logger.error, stderrdata)
-                unlink(fifo_fp)
+        self._derive_with_pil(
+            im=im,
+            target_fp=target_fp,
+            image_request=image_request,
+            image_info=image_info,
+            crop=False
+        )
 
-           try:
-                if self.map_profile_to_srgb and image_request.info.color_profile_bytes:  # i.e. is not None
-                    emb_profile = BytesIO(image_request.info.color_profile_bytes)
-                    im = self._map_im_profile_to_srgb(im, emb_profile)
-           except PyCMSError as err:
-                logger.warn('Error converting %r to sRGB: %r', im, err)
+    def transform(self, target_fp, image_request, image_info):
+        # opj writes to this:
+        fifo_fp = self._make_tmp_fp()
 
-           self._derive_with_pil(im, target_fp, image_request, crop=False)
-
-        def transform(self, src_fp, target_fp, image_request):
-            fifo_fp = self._make_tmp_fp()
-            mkfifo_call = '%s %s' % (self.mkfifo, fifo_fp)
-            subprocess.check_call(mkfifo_call, shell=True)
-            if resp != 0:
-                logger.error('Problem with opj mkfifo')
+        # make the named pipe
+        mkfifo_call = '%s %s' % (self.mkfifo, fifo_fp)
+        logger.debug('Calling %s', mkfifo_call)
+        resp = subprocess.check_call(mkfifo_call, shell=True)
+        if resp != 0:
+            logger.error('Problem with mkfifo')
             # how to handle CalledProcessError; would have to be a 500?
+            raise TransformException('opj error: Problem with mkfifo')
 
-            # opj_decompress command
-            i = '-i "%s"' % (src_fp,)
-            o = '-o %s' % (fifo_fp,)
-            region_arg = self._region_to_opj_arg(image_request.region_param)
-            reg = '-d %s' % (region_arg,) if region_arg else ''
-            reduce_arg = self._scales_to_reduce_arg(image_request)
-            red = '-r %s' % (reduce_arg,) if reduce_arg else ''
-            opj_cmd = ' '.join((self.opj_decompress,i,reg,red,o))
+        # opj_decompress command
+        i = '-i "%s"' % (image_info.src_img_fp,)
+        o = '-o %s' % (fifo_fp,)
+        region_arg = self._region_to_opj_arg(image_request.region_param(image_info))
+        reg = '-d %s' % (region_arg,) if region_arg else ''
+        reduce_arg = self._scales_to_reduce_arg(image_request, image_info)
+        red = '-r %s' % (reduce_arg,) if reduce_arg else ''
 
+        opj_cmd = ' '.join((self.opj_decompress,i,reg,red,o))
 
-            process = multiprocessing.Process(target=self._run_transform,
-                        args=(target_fp, image_request, opj_cmd, fifo_fp))
+        logger.debug('Calling: %s', opj_cmd)
 
-            process.start()
-            process.join(self.transform_timeout)
-            if process.is_alive():
-                logger.info('terminating process for %s, %s', src_fp, target_fp)
-                process.terminate()
-                if path.exists(fifo_fp):
-                    unlink(fifo_fp)
-                raise TransformException('opj transform process timed out')
+        process = multiprocessing.Process(
+            target=self._run_transform,
+            kwargs={
+                'target_fp': target_fp,
+                'image_request': image_request,
+                'image_info': image_info,
+                'opj_cmd': opj_cmd,
+                'fifo_fp': fifo_fp
+            }
+        )
+        process.start()
+        process.join(self.transform_timeout)
+        if process.is_alive():
+            logger.info('terminating process for %s, %s',
+                image_info.src_img_fp, target_fp)
+            process.terminate()
+            if path.exists(fifo_fp):
+                unlink(fifo_fp)
+            raise TransformException('transform process timed out')
 
 class KakaduJP2Transformer(_AbstractJP2Transformer):
 
@@ -396,7 +441,7 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
         logger.debug('kdu region parameter: %s', arg)
         return arg
 
-    def _run_transform(self, target_fp, image_request, kdu_cmd, fifo_fp):
+    def _run_transform(self, target_fp, image_request, image_info, kdu_cmd, fifo_fp):
         try:
             # Start the kdu shellout. Blocks until the pipe is empty
             kdu_expand_proc = subprocess.Popen(kdu_cmd, shell=True, bufsize=-1,
@@ -411,22 +456,28 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
                     p.feed(s)
                 im = p.close() # a PIL.Image
         finally:
-            stdoutdata, stderrdata = kdu_expand_proc.communicate()
+            _, stderrdata = kdu_expand_proc.communicate()
             kdu_exit = kdu_expand_proc.returncode
             if kdu_exit != 0:
                 map(logger.error, stderrdata)
             unlink(fifo_fp)
 
         try:
-            if self.map_profile_to_srgb and image_request.info.color_profile_bytes:  # i.e. is not None
-                emb_profile = BytesIO(image_request.info.color_profile_bytes)
+            if self.map_profile_to_srgb and image_info.color_profile_bytes:
+                emb_profile = BytesIO(image_info.color_profile_bytes)
                 im = self._map_im_profile_to_srgb(im, emb_profile)
         except PyCMSError as err:
             logger.warn('Error converting %r to sRGB: %r', im, err)
 
-        self._derive_with_pil(im, target_fp, image_request, crop=False)
+        self._derive_with_pil(
+            im=im,
+            target_fp=target_fp,
+            image_request=image_request,
+            image_info=image_info,
+            crop=False
+        )
 
-    def transform(self, src_fp, target_fp, image_request):
+    def transform(self, target_fp, image_request, image_info):
         fifo_fp = self._make_tmp_fp()
         mkfifo_call = '%s %s' % (self.mkfifo, fifo_fp)
         subprocess.check_call(mkfifo_call, shell=True)
@@ -434,22 +485,30 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
         # kdu command
         q = '-quiet'
         t = '-num_threads %s' % self.num_threads
-        i = '-i "%s"' % src_fp
+        i = '-i "%s"' % image_info.src_img_fp
         o = '-o %s' % fifo_fp
-        reduce_arg = self._scales_to_reduce_arg(image_request)
+        reduce_arg = self._scales_to_reduce_arg(image_request, image_info)
         red = '-reduce %s' % (reduce_arg,) if reduce_arg else ''
-        region_arg = self._region_to_kdu_arg(image_request.region_param)
+        region_arg = self._region_to_kdu_arg(image_request.region_param(image_info))
         reg = '-region %s' % (region_arg,) if region_arg else ''
         kdu_cmd = ' '.join((self.kdu_expand,q,i,t,reg,red,o))
 
-        process = multiprocessing.Process(target=self._run_transform,
-                                          args=(target_fp, image_request, kdu_cmd, fifo_fp))
+        process = multiprocessing.Process(
+            target=self._run_transform,
+            kwargs={
+                'target_fp': target_fp,
+                'image_request': image_request,
+                'image_info': image_info,
+                'kdu_cmd': kdu_cmd,
+                'fifo_fp': fifo_fp
+            }
+        )
         process.start()
         process.join(self.transform_timeout)
         if process.is_alive():
-            logger.info('terminating process for %s, %s', src_fp, target_fp)
+            logger.info('terminating process for %s, %s',
+                image_info.src_img_fp, target_fp)
             process.terminate()
             if path.exists(fifo_fp):
                 unlink(fifo_fp)
             raise TransformException('transform process timed out')
-

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -1,4 +1,4 @@
-u transformers.py
+# transformers.py
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -288,8 +288,8 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
                 x1 = region_param.pixel_x + region_param.pixel_w
                 y1 = region_param.pixel_y + region_param.pixel_h
                 arg = ','.join(map(str, (x0, y0, x1, y1)))
-             logger.debug('opj region parameter: %s', arg)
-             return arg
+            logger.debug('opj region parameter: %s', arg)
+            return arg
 
         def _run_transform(self, target_fp, image_request, opj_cmd, fifo_fp):
            try:

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -257,8 +257,8 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
             }
             #super(OPJ_JP2Transformer, self).__init__(config)
             #new
-           self.transform_timeout = config.get('timeout', 120)
-           super(OPJ_JP2Transformer, self).__init__(config)
+            self.transform_timeout = config.get('timeout', 120)
+            super(OPJ_JP2Transformer, self).__init__(config)
 
 
         @staticmethod

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -304,7 +304,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
                         if not s:
                             break
                         p.feed(s)
-                     im = p.close() # a PIL.Image
+                    im = p.close() # a PIL.Image
            finally:
                 stdoutdata, stderrdata = opj_expand_proc.communicate()
                 opj_exit = opj_expand_proc.returncode
@@ -329,14 +329,14 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
                 logger.error('Problem with opj mkfifo')
             # how to handle CalledProcessError; would have to be a 500?
 
-             # opj_decompress command
-             i = '-i "%s"' % (src_fp,)
-             o = '-o %s' % (fifo_fp,)
-             region_arg = self._region_to_opj_arg(image_request.region_param)
-             reg = '-d %s' % (region_arg,) if region_arg else ''
-             reduce_arg = self._scales_to_reduce_arg(image_request)
-             red = '-r %s' % (reduce_arg,) if reduce_arg else ''
-             opj_cmd = ' '.join((self.opj_decompress,i,reg,red,o))
+            # opj_decompress command
+            i = '-i "%s"' % (src_fp,)
+            o = '-o %s' % (fifo_fp,)
+            region_arg = self._region_to_opj_arg(image_request.region_param)
+            reg = '-d %s' % (region_arg,) if region_arg else ''
+            reduce_arg = self._scales_to_reduce_arg(image_request)
+            red = '-r %s' % (reduce_arg,) if reduce_arg else ''
+            opj_cmd = ' '.join((self.opj_decompress,i,reg,red,o))
 
 
             process = multiprocessing.Process(target=self._run_transform,

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -189,6 +189,9 @@ class _PillowTransformer(_AbstractTransformer):
 class JPG_Transformer(_PillowTransformer):
     def __init__(self, config): super(JPG_Transformer, self).__init__(config)
 
+class GIF_Transformer(_PillowTransformer):
+    def __init__(self, config): super(GIF_Transformer, self).__init__(config)
+
 class TIF_Transformer(_PillowTransformer):
     def __init__(self, config): super(TIF_Transformer, self).__init__(config)
 

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -731,17 +731,19 @@ possible that there was a problem with the source file
         #jp2 failover, use both transforms if loaded
         if isinstance(transformer, tuple):
           transformer1 = transformer[0]
+          t1_name = type(transformer1).__name__
           transformer2 = transformer[1]
+          t2_name = type(transformer2).__name__
           self.logger.debug('dual transformers detected')
           try:
-            self.logger.debug('using transformer #1')
+            self.logger.debug('using transformer #1: %s ' % t1_name)
             transformer1.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
           except TransformException:
-            self.logger.debug('failing over to transformer #2')
+            self.logger.debug('failing over to transformer #2: %s' % t2_name)
             transformer2.transform(
               target_fp=temp_fp,
               image_request=image_request,

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -728,23 +728,30 @@ possible that there was a problem with the source file
         temp_fp = temp_file.name
 
         transformer = self.transformers[image_info.src_format]
+        self.logger.debug( transformer )
         #jp2 failover, use both transforms if loaded
         if isinstance(transformer, list):
           transformer1 = transformer[0]
           transformer2 = transformer[1]
+          self.logger.debug(transformer[0])
+          self.logger.debug(transformer[1])
+          self.logger.debug('dual jp2 transformers detected')
           try:
+            self.logger.debug('using jp2 transformer #1')
             transformer1.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
           except TransformException:
+            self.logger.debug('failing over to jp2 transformer #2')
             transformer2.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
         else:
+          self.logger.debug('using single transformer')
           transformer.transform(
             target_fp=temp_fp,
             image_request=image_request,

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -728,9 +728,8 @@ possible that there was a problem with the source file
         temp_fp = temp_file.name
 
         transformer = self.transformers[image_info.src_format]
-        self.logger.debug( transformer )
         #jp2 failover, use both transforms if loaded
-        if isinstance(transformer, list):
+        if isinstance(transformer, tuple):
           transformer1 = transformer[0]
           transformer2 = transformer[1]
           self.logger.debug(transformer[0])
@@ -751,7 +750,6 @@ possible that there was a problem with the source file
               image_info=image_info
             )
         else:
-          self.logger.debug('using single transformer')
           transformer.transform(
             target_fp=temp_fp,
             image_request=image_request,

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -357,10 +357,20 @@ class Loris(object):
         return transformers
 
     def _load_transformer(self, config):
-        Klass = getattr(transforms, config['impl'])
-        instance = Klass(config)
-        self.logger.debug('Loaded Transformer %s', config['impl'])
-        return instance
+	#jp2 use kdu and opj for failover
+	if 'impl2' in config:
+	  Klass = getattr(transforms, config['impl'])
+	  instance = Klass(config)
+	  self.logger.debug('Loaded Primary Transformer %s', config['impl']) 
+	  Klass = getattr(transforms, config['impl2'])
+	  instance2 = Klass(config)
+	  self.logger.debug('Loaded Secondary Transformer %s', config['impl2'])
+	  return instance, instance2
+	else:
+          Klass = getattr(transforms, config['impl'])
+          instance = Klass(config)
+          self.logger.debug('Loaded Transformer %s', config['impl'])
+          return instance
 
     def _load_resolver(self):
         impl = self.app_configs['resolver']['impl']
@@ -718,11 +728,28 @@ possible that there was a problem with the source file
         temp_fp = temp_file.name
 
         transformer = self.transformers[image_info.src_format]
-        transformer.transform(
+	#jp2 failover, use both transforms if loaded
+	if isinstance(transformer, list):
+	  transformer1 = transformer[0]
+	  transformer2 = transformer[1]
+	  try:
+	    transformer1.transform(
+              target_fp=temp_fp,
+              image_request=image_request,
+              image_info=image_info
+            )
+	  except TransformException:
+	    transformer2.transform(
+              target_fp=temp_fp,
+              image_request=image_request,
+              image_info=image_info
+            )
+	else:
+          transformer.transform(
             target_fp=temp_fp,
             image_request=image_request,
             image_info=image_info
-        )
+          )
 
         if self.enable_caching:
             temp_fp = self.img_cache.upsert(

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -728,23 +728,23 @@ possible that there was a problem with the source file
         temp_fp = temp_file.name
 
         transformer = self.transformers[image_info.src_format]
-	#jp2 failover, use both transforms if loaded
-	if isinstance(transformer, list):
-	  transformer1 = transformer[0]
-	  transformer2 = transformer[1]
-	  try:
-	    transformer1.transform(
+        #jp2 failover, use both transforms if loaded
+        if isinstance(transformer, list):
+          transformer1 = transformer[0]
+          transformer2 = transformer[1]
+          try:
+            transformer1.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
-	  except TransformException:
-	    transformer2.transform(
+          except TransformException:
+            transformer2.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
-	else:
+        else:
           transformer.transform(
             target_fp=temp_fp,
             image_request=image_request,

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -357,16 +357,16 @@ class Loris(object):
         return transformers
 
     def _load_transformer(self, config):
-	#jp2 use kdu and opj for failover
-	if 'impl2' in config:
-	  Klass = getattr(transforms, config['impl'])
-	  instance = Klass(config)
-	  self.logger.debug('Loaded Primary Transformer %s', config['impl']) 
-	  Klass = getattr(transforms, config['impl2'])
-	  instance2 = Klass(config)
-	  self.logger.debug('Loaded Secondary Transformer %s', config['impl2'])
-	  return instance, instance2
-	else:
+        #jp2 use kdu and opj for failover
+        if 'impl2' in config:
+          Klass = getattr(transforms, config['impl'])
+          instance = Klass(config)
+          self.logger.debug('Loaded Primary Transformer %s', config['impl']) 
+          Klass = getattr(transforms, config['impl2'])
+          instance2 = Klass(config)
+          self.logger.debug('Loaded Secondary Transformer %s', config['impl2'])
+          return instance, instance2
+        else:
           Klass = getattr(transforms, config['impl'])
           instance = Klass(config)
           self.logger.debug('Loaded Transformer %s', config['impl'])

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -732,18 +732,16 @@ possible that there was a problem with the source file
         if isinstance(transformer, tuple):
           transformer1 = transformer[0]
           transformer2 = transformer[1]
-          self.logger.debug(transformer[0])
-          self.logger.debug(transformer[1])
-          self.logger.debug('dual jp2 transformers detected')
+          self.logger.debug('dual transformers detected')
           try:
-            self.logger.debug('using jp2 transformer #1')
+            self.logger.debug('using transformer #1')
             transformer1.transform(
               target_fp=temp_fp,
               image_request=image_request,
               image_info=image_info
             )
           except TransformException:
-            self.logger.debug('failing over to jp2 transformer #2')
+            self.logger.debug('failing over to transformer #2')
             transformer2.transform(
               target_fp=temp_fp,
               image_request=image_request,


### PR DESCRIPTION
Loris will now run with kakadu and openjpeg installed, and failover to the secondary transformer to complete the request. 

To set it up, the jp2 config section in your loris2.conf file should look like this:

[[jp2]]
         timeout = 45
         src_format = 'jp2'
         impl = 'KakaduJP2Transformer'
         kdu_expand = '/usr/local/bin/kdu_expand'
         kdu_libs = '/usr/local/lib'
         num_threads = '4'
         tmp_dp = '/tmp/loris2'

         impl2 = 'OPJ_JP2Transformer'
         opj_decompress = '/usr/local/bin/opj_decompress' # r-x
         opj_libs = '/usr/local/lib' # r--
         mkfifo = '/usr/bin/mkfifo' # r-x
         map_profile_to_srgb = False
         srgb_profile_fp = '/usr/share/color/icc/colord/sRGB.icc' # r--